### PR TITLE
Kebabs on everything :)

### DIFF
--- a/lib/HTTP/Parser.pm6
+++ b/lib/HTTP/Parser.pm6
@@ -2,54 +2,53 @@ use v6;
 
 unit module HTTP::Parser;
 
-my Buf $http_header_end_marker = Buf.new(13, 10, 13, 10);
+my Buf $http-header-end-marker = Buf.new(13, 10, 13, 10);
 
 # >0: header size
 # -1: failed
 # -2: request is partial
 sub parse-http-request(Blob $req) is export {
-    my Int $header_end_pos = 0;
-    while ( $header_end_pos < $req.bytes ) {
-        if ($http_header_end_marker eq $req.subbuf($header_end_pos, 4)) {
+    my Int $header-end-pos = 0;
+    while ( $header-end-pos < $req.bytes ) {
+        if ($http-header-end-marker eq $req.subbuf($header-end-pos, 4)) {
             last;
         }
-        $header_end_pos++;
+        $header-end-pos++;
     }
 
-    if ($header_end_pos < $req.bytes) {
-        my @header_lines = $req.subbuf(
-            0, $header_end_pos
+    if ($header-end-pos < $req.bytes) {
+        my @header-lines = $req.subbuf(
+            0, $header-end-pos
         ).decode('ascii').subst(/^(\r\n)*/, '').split(/\r\n/);
 
         my $env = {
-            :SCRIPT_NAME('')
+            :SCRIPT-NAME('')
         };
 
-        my Str $status_line = @header_lines.shift;
-        if $status_line ~~ m/^(<[A..Z]>+)\s(\S+)\sHTTP\/1\.(<[01]>)$/ {
-            $env<REQUEST_METHOD> = $/[0].Str;
-            $env<SERVER_PROTOCOL> = "HTTP/1.{$/[2].Str}";
-            my $path_query = $/[1].Str;
-            $env<REQUEST_URI> = $path_query;
-            if $path_query ~~ m/^ (.*?) [ \? (.*) ]? $/ {
+        my Str $status-line = @header-lines.shift;
+        if $status-line ~~ m/^(<[A..Z]>+)\s(\S+)\sHTTP\/1\.(<[01]>)$/ {
+            $env<REQUEST-METHOD> = $/[0].Str;
+            $env<SERVER-PROTOCOL> = "HTTP/1.{$/[2].Str}";
+            my $path-query = $/[1].Str;
+            $env<REQUEST-URI> = $path-query;
+            if $path-query ~~ m/^ (.*?) [ \? (.*) ]? $/ {
                 my $path = $/[0].Str;
                 my $query = ($/[1] // '').Str;
-                $env<PATH_INFO> = $path.subst(:g, /\%(<[0..9 a..f A..F]> ** 2)/, -> {
+                $env<PATH-INFO> = $path.subst(:g, /\%(<[0..9 a..f A..F]> ** 2)/, -> {
                      :16($/[0].Str).chr
                 });
-                $env<QUERY_STRING> = $query;
+                $env<QUERY-STRING> = $query;
             }
         } else {
             return -2,Nil;
         }
 
-        for @header_lines {
+        for @header-lines {
             if $_ ~~ m/ ^^ ( <[ A..Z a..z - ]>+ ) \s* \: \s* (.+) $$ / {
                 my ($k, $v) = @($/);
-                $k = $k.subst(/\-/, '_', :g);
                 $k = $k.uc;
-                if $k ne 'CONTENT_LENGTH' && $k ne 'CONTENT_TYPE' {
-                    $k = 'HTTP_' ~ $k;
+                if $k ne 'CONTENT-LENGTH' && $k ne 'CONTENT-TYPE' {
+                    $k = 'HTTP-' ~ $k;
                 }
                 $env{$k} = $v.Str;
             } else {
@@ -57,7 +56,7 @@ sub parse-http-request(Blob $req) is export {
             }
         }
 
-        return $header_end_pos+4, $env;
+        return $header-end-pos+4, $env;
     } else {
         return -1,Nil;
     }
@@ -75,7 +74,7 @@ HTTP::Parser - HTTP parser.
 
     my ($result, $env) = parse-http-request("GET / HTTP/1.0\r\ncontent-type: text/html\r\n\r\n".encode("ascii"));
     # $result => 43
-    # $env => ${:CONTENT_TYPE("text/html"), :PATH_INFO("/"), :QUERY_STRING(""), :REQUEST_METHOD("GET")}
+    # $env => ${:CONTENT-TYPE("text/html"), :PATH-INFO("/"), :QUERY-STRING(""), :REQUEST-METHOD("GET")}
 
 =head1 DESCRIPTION
 

--- a/t/01-request-parser.t
+++ b/t/01-request-parser.t
@@ -6,53 +6,53 @@ use HTTP::Parser;
 my @cases =
     ["GET / HTTP/1.0\r\n\r\n", [
         18, {
-            :PATH_INFO("/"),
-            :QUERY_STRING(""),
-            :REQUEST_METHOD("GET"),
-            :SERVER_PROTOCOL("HTTP/1.0"),
-            :REQUEST_URI</>,
-            :SCRIPT_NAME(''),
+            :PATH-INFO("/"),
+            :QUERY-STRING(""),
+            :REQUEST-METHOD("GET"),
+            :SERVER-PROTOCOL("HTTP/1.0"),
+            :REQUEST-URI</>,
+            :SCRIPT-NAME(''),
         }
     ]],
     ["\r\nGET / HTTP/1.0\r\n\r\n", [ # pre-header blank lines are allowed (RFC 2616 4.1)
         20, {
-            :PATH_INFO("/"),
-            :QUERY_STRING(""),
-            :REQUEST_METHOD("GET"),
-            :SERVER_PROTOCOL("HTTP/1.0"),
-            :REQUEST_URI</>,
-            :SCRIPT_NAME(''),
+            :PATH-INFO("/"),
+            :QUERY-STRING(""),
+            :REQUEST-METHOD("GET"),
+            :SERVER-PROTOCOL("HTTP/1.0"),
+            :REQUEST-URI</>,
+            :SCRIPT-NAME(''),
         }
     ]],
     ["GET / HTTP/1.1\r\ncontent-type: text/html\r\n\r\n", [
         43, {
-            :CONTENT_TYPE("text/html"),
-            :PATH_INFO("/"),
-            :QUERY_STRING(""),
-            :REQUEST_METHOD("GET"),
-            :SERVER_PROTOCOL("HTTP/1.1"),
-            :REQUEST_URI</>,
-            :SCRIPT_NAME(''),
+            :CONTENT-TYPE("text/html"),
+            :PATH-INFO("/"),
+            :QUERY-STRING(""),
+            :REQUEST-METHOD("GET"),
+            :SERVER-PROTOCOL("HTTP/1.1"),
+            :REQUEST-URI</>,
+            :SCRIPT-NAME(''),
         }
     ]],
     ["GET /foo?bar=3 HTTP/1.1\r\n\r\n", [
         27, {
-            :PATH_INFO("/foo"),
-            :QUERY_STRING("bar=3"),
-            :REQUEST_METHOD("GET"),
-            :SERVER_PROTOCOL("HTTP/1.1"),
-            :REQUEST_URI</foo?bar=3>,
-            :SCRIPT_NAME(''),
+            :PATH-INFO("/foo"),
+            :QUERY-STRING("bar=3"),
+            :REQUEST-METHOD("GET"),
+            :SERVER-PROTOCOL("HTTP/1.1"),
+            :REQUEST-URI</foo?bar=3>,
+            :SCRIPT-NAME(''),
         }
     ]],
     ["GET /foo%2A%2c?bar=3 HTTP/1.1\r\n\r\n", [
         33, {
-            REQUEST_METHOD => 'GET',
-            PATH_INFO => '/foo*,',
-            QUERY_STRING => 'bar=3',
-            SERVER_PROTOCOL => 'HTTP/1.1',
-            :REQUEST_URI</foo%2A%2c?bar=3>,
-            :SCRIPT_NAME(''),
+            REQUEST-METHOD => 'GET',
+            PATH-INFO => '/foo*,',
+            QUERY-STRING => 'bar=3',
+            SERVER-PROTOCOL => 'HTTP/1.1',
+            :REQUEST-URI</foo%2A%2c?bar=3>,
+            :SCRIPT-NAME(''),
         }
     ]],
     ["GET / HTTP/1.0\r\n", [


### PR DESCRIPTION
Just in case you'd like it that way.

We could also provide:

CONTENT-TYPE
CONTENT_TYPE
content-type

All available on %env. Just use one canonical: maybe the lower-kebab-case form:

```
# munge $uc-k, $uc_k

%h{ $k } = $v

%h{ $uc-k } := %h{ $k }
%h{ $uc_k } := %h{ $k }
```

But then again, maybe having only one option is cleaner.
