### PR TITLE
Avoid attempting to parse non ascii body parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /src/*.o
 /src/Makefile
 /.panda-work
+.precomp

--- a/lib/HTTP/Parser.pm6
+++ b/lib/HTTP/Parser.pm6
@@ -97,7 +97,11 @@ my class HTTPRequestHeadAction {
 # >0: header size
 # -1: failed
 # -2: request is partial
-sub parse-http-request(Blob $req) is export {
+sub parse-http-request(Blob $req is copy) is export {
+    my $k = $req.first(* > 127, :k);
+    if $k !~~ Nil {
+        $req = $req.subbuf(0, $k);
+    }
     my $decoded = $req.decode('ascii');
 
     my $actions = HTTPRequestHeadAction.new();

--- a/t/02-issue-4.t
+++ b/t/02-issue-4.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl6
+
+use v6.c;
+
+use Test;
+use HTTP::Parser;
+
+my $test = "GET / HTTP/1.0\x[0d]\x[0a]User-Agent: a b c\x[0d]\x[0a]\x[0d]\x[0a]Hepæstus was a strange øld þing";
+
+# by default it would give a utf8 buf which subsequently
+# won't be decoded.
+my $buf = Buf.new($test.encode.list);
+
+# don't need to check the whole thing
+lives-ok {
+    my ($retval, $env) = parse-http-request($buf);
+    ok $retval, "got retval";
+    is $env<REQUEST_METHOD>, 'GET', "got the right REQUEST METHOD";
+    is $env<HTTP_USER_AGENT>, 'a b c', "and the user agent string";
+
+}, "can parse one with a unicode body";
+
+
+done-testing;
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
Hi,
This is a fix for the #4 that I sent on Friday.

I've taken the simplest possible approach as there didn't seem to be much point in scanning for the end of the header when the parser already does that, so it will just find the first non-ascii character in the buffer and truncates the buffer to be encoded up to that point.  The parser will work the same otherwise.

