### PR TITLE
Need binding to preserve Nilness

### DIFF
--- a/lib/HTTP/Parser.pm6
+++ b/lib/HTTP/Parser.pm6
@@ -98,7 +98,7 @@ my class HTTPRequestHeadAction {
 # -1: failed
 # -2: request is partial
 sub parse-http-request(Blob $req is copy) is export {
-    my $k = $req.first(* > 127, :k);
+    my $k := $req.first(* > 127, :k);
     if $k !~~ Nil {
         $req = $req.subbuf(0, $k);
     }


### PR DESCRIPTION
When you assign the `Nil` value to a variable without any typing, it becomes an `Any`, which will cause the `If` to fire.