### PR TITLE
Simply check for definedness of the return of first

### DIFF
--- a/lib/HTTP/Parser.pm6
+++ b/lib/HTTP/Parser.pm6
@@ -99,7 +99,7 @@ my class HTTPRequestHeadAction {
 # -2: request is partial
 sub parse-http-request(Blob $req is copy) is export {
     my $k := $req.first(* > 127, :k);
-    if $k !~~ Nil {
+    if $k.defined {
         $req = $req.subbuf(0, $k);
     }
     my $decoded = $req.decode('ascii');

--- a/t/01-request-parser.t
+++ b/t/01-request-parser.t
@@ -82,12 +82,23 @@ my @cases =
             :SCRIPT_NAME(''),
         }
     ]],
+    ["GET / HTTP/1.1\x[0d]\x[0a]content-type: text/html\x[0d]\x[0a]\x[0d]\x[0a]öØh", [
+        43, {
+            :CONTENT_TYPE("text/html"),
+            :PATH_INFO("/"),
+            :QUERY_STRING(""),
+            :REQUEST_METHOD("GET"),
+            :SERVER_PROTOCOL("HTTP/1.1"),
+            :REQUEST_URI</>,
+            :SCRIPT_NAME(''),
+        }
+    ]],
 ;
 
 for @cases {
     my ($req, $expected) = @($_);
     subtest {
-        my ($retval, $env) = parse-http-request($req.encode('ascii'));
+        my ($retval, $env) = parse-http-request($req.encode);
         is $retval, $expected[0], 'header size';
         if $retval >= 0 {
             is-deeply $env, $expected[1];


### PR DESCRIPTION
The subbuf with an undefined second argument is deprecated now
so the simple .defined test is more robust.

Added a test to make sure that it really does catch the non-ascii
characters that definitely aren't part of the header.

Fixes #9